### PR TITLE
maxpool primitive

### DIFF
--- a/src/lib.jl
+++ b/src/lib.jl
@@ -85,10 +85,10 @@ shape(::typeof(softmax), x) = shape(x)
   overdub(Trace(), (x, σ, b) -> (σ).(x .+ b), conv, σ, b)
 end
 
-jscall(::typeof(conv2d), x...) = jscall(:(dl.conv2d), x...)
+jscall(::typeof(conv2d), x...) = jscall(:(tf.conv2d), x...)
 
-shape(::typeof(conv2d), x, weight, stride, pad) =
-  Shape{Int64}(cdims(size(x), size(weight), padtuple(x, pad), stride))
+shape(::typeof(conv2d), x::Shape{T}, weight, stride, pad) where T =
+  Shape{T}(cdims(size(x), size(weight), padtuple(x, pad), stride))
 
 # maxpool
 
@@ -102,7 +102,7 @@ end
 
 jscall(::typeof(maxpool), x, k, pad, stride) = jscall(:(math.maxpool), x, k, stride, pad)
 
-shape(::typeof(maxpool), x, k, pad, stride) = Shape{Int64}(pdims(size(x), k, padtuple(x, pad), stride))
+shape(::typeof(maxpool), x::Shape{T}, k, pad, stride) where T = Shape{T}(pdims(size(x), k, padtuple(x, pad), stride))
 
 # broadcasted ops
 

--- a/src/lib.jl
+++ b/src/lib.jl
@@ -100,7 +100,7 @@ shape(::typeof(conv2d), x::Shape{T}, weight, stride, pad) where T =
   StagedArray(maxpool, x, k, pad, stride)
 end
 
-jscall(::typeof(maxpool), x, k, pad, stride) = jscall(:(math.maxpool), x, k, stride, pad)
+jscall(::typeof(maxpool), x, k, pad, stride) = jscall(:(math.maxPool), x, k, stride, pad)
 
 shape(::typeof(maxpool), x::Shape{T}, k, pad, stride) where T = Shape{T}(pdims(size(x), k, padtuple(x, pad), stride))
 


### PR DESCRIPTION
Depends on [Vinyl.jl#3](https://github.com/MikeInnes/Vinyl.jl/pull/3)

```julia
m = Chain(Conv((2, 2), 3=>1), x->maxpool(x, (2, 2)))
Chain(Conv((2, 2), 3=>1), #1)
```
produces
```javascript
let model = (function () {
  let math = dl.ENV.math;
  function waterbuffalo(dove) {
    return math.maxpool(dove, [2, 2], [2, 2], 0);
  };
  function model(chimpanzee) {
    return waterbuffalo(math.add(dl.conv2d(chimpanzee, model.weights[0], [1, 1], 0), model.weights[1]));
  };
  model.weights = [];
  return model;
})();
flux.fetchWeights("model.bson").then((function (ws) {
  return model.weights = ws;
}));
```