### PR TITLE
Added support for LSTM and BatchNorm

### DIFF
--- a/lib/flux.js
+++ b/lib/flux.js
@@ -71,6 +71,12 @@ function getprop(obj, prop){
   return obj[prop]
 }
 
-return {fetchData, fetchWeights, fetchBlob, getprop};
+const add = (a, b) => a + b;
+const sub = (a, b) => a - b;
+const mul = (a, b) => a * b;
+const div = (a, b) => a / b;
+const _data = t => (t instanceof tf.Tensor)? t.dataSync(): t;
+
+return {fetchData, fetchWeights, fetchBlob, getprop, add, sub, mul, div, data: _data};
 
 })();

--- a/lib/flux.js
+++ b/lib/flux.js
@@ -77,7 +77,9 @@ async function fetchWeights(url) {
 }
 
 const _data = t => (t instanceof tf.Tensor)? t.dataSync(): t;
+const slice = t => (t instanceof tf.Tensor)? t.clone():(
+  t instanceof Array ? t.slice() : t);
 
-return {fetchData, fetchWeights, fetchBlob, data: _data};
+return {fetchData, fetchWeights, fetchBlob, data: _data, slice};
 
 })();

--- a/lib/flux.js
+++ b/lib/flux.js
@@ -66,16 +66,12 @@ async function fetchWeights(url) {
   return ws.weights;
 }
 
-function getprop(obj, prop){
-  return obj[prop]
-}
-
 const add = (a, b) => a + b;
 const sub = (a, b) => a - b;
 const mul = (a, b) => a * b;
 const div = (a, b) => a / b;
 const _data = t => (t instanceof tf.Tensor)? t.dataSync(): t;
 
-return {fetchData, fetchWeights, fetchBlob, getprop, add, sub, mul, div, data: _data};
+return {fetchData, fetchWeights, fetchBlob, add, sub, mul, div, data: _data};
 
 })();

--- a/lib/flux.js
+++ b/lib/flux.js
@@ -75,7 +75,12 @@ const sub = (a, b) => a - b;
 const mul = (a, b) => a * b;
 const div = (a, b) => a / b;
 const _data = t => (t instanceof tf.Tensor)? t.dataSync(): t;
+const shape = function(t){
+  if(t instanceof tf.Tensor) return t.shape;
+  if(t instanceof Array) return [t.length].concat(shape(t[0]))
+  return [];
+}
 
-return {fetchData, fetchWeights, fetchBlob, getprop, add, sub, mul, div, data: _data};
+return {fetchData, fetchWeights, fetchBlob, getprop, add, sub, mul, div, data: _data, shape};
 
 })();

--- a/lib/flux.js
+++ b/lib/flux.js
@@ -67,6 +67,10 @@ async function fetchWeights(url) {
   return ws.weights;
 }
 
-return {fetchData, fetchWeights, fetchBlob};
+function getprop(obj, prop){
+  return obj[prop]
+}
+
+return {fetchData, fetchWeights, fetchBlob, getprop};
 
 })();

--- a/lib/flux.js
+++ b/lib/flux.js
@@ -75,12 +75,7 @@ const sub = (a, b) => a - b;
 const mul = (a, b) => a * b;
 const div = (a, b) => a / b;
 const _data = t => (t instanceof tf.Tensor)? t.dataSync(): t;
-const shape = function(t){
-  if(t instanceof tf.Tensor) return t.shape;
-  if(t instanceof Array) return [t.length].concat(shape(t[0]))
-  return [];
-}
 
-return {fetchData, fetchWeights, fetchBlob, getprop, add, sub, mul, div, data: _data, shape};
+return {fetchData, fetchWeights, fetchBlob, getprop, add, sub, mul, div, data: _data};
 
 })();

--- a/lib/flux.js
+++ b/lib/flux.js
@@ -66,12 +66,8 @@ async function fetchWeights(url) {
   return ws.weights;
 }
 
-const add = (a, b) => a + b;
-const sub = (a, b) => a - b;
-const mul = (a, b) => a * b;
-const div = (a, b) => a / b;
 const _data = t => (t instanceof tf.Tensor)? t.dataSync(): t;
 
-return {fetchData, fetchWeights, fetchBlob, add, sub, mul, div, data: _data};
+return {fetchData, fetchWeights, fetchBlob, data: _data};
 
 })();

--- a/src/compile.jl
+++ b/src/compile.jl
@@ -77,12 +77,14 @@ function prepare(ex, name, states = nothing)
     :(init = $states; states = init.slice())
   reset_method = states == nothing ? :(;) :
     :(model.reset = () -> (global states = init.slice(); return);)
+  get_states = states == nothing? :(;) : :(model.getStates = () -> (return states);)
   quote
     model = (() -> begin
       math = dl.ENV.math
       $(state_setup.args...)
       model = $(ex)
       $(reset_method.args...)
+      $(get_states.args...)
       model.weights = []
       model
     end)()

--- a/src/compile.jl
+++ b/src/compile.jl
@@ -73,6 +73,7 @@ function insert_returns(ex)
 end
 
 function prepare(ex, name, states = nothing)
+  @show ex
   state_setup = states == nothing ? :(;) :
     :(init = $states; states = init.slice())
   reset_method = states == nothing ? :(;) :

--- a/src/compile.jl
+++ b/src/compile.jl
@@ -73,7 +73,6 @@ function insert_returns(ex)
 end
 
 function prepare(ex, name, states = nothing)
-  @show ex
   state_setup = states == nothing ? :(;) :
     :(init = $states; states = init.slice())
   reset_method = states == nothing ? :(;) :

--- a/src/dump.jl
+++ b/src/dump.jl
@@ -82,6 +82,9 @@ function jsexpr(io::IO, x; level = 0)
     x.args[1] == nothing && return print(io, "return")
     print(io, "return ")
     jsexpr(io, x.args[1], level = level)
+  elseif isexpr(x, :ref) && isexpr(x.args[1], :tuple)
+    jsexpr(io, x.args[1])
+    print(io, "[$(x.args[2])]")
   else
     print(io, x)
   end

--- a/src/dump.jl
+++ b/src/dump.jl
@@ -82,7 +82,7 @@ function jsexpr(io::IO, x; level = 0)
     x.args[1] == nothing && return print(io, "return")
     print(io, "return ")
     jsexpr(io, x.args[1], level = level)
-  elseif isexpr(x, :ref) && isexpr(x.args[1], :tuple)
+  elseif isexpr(x, :ref)
     jsexpr(io, x.args[1])
     print(io, "[$(x.args[2])]")
   else

--- a/src/lib.jl
+++ b/src/lib.jl
@@ -195,10 +195,10 @@ binary_op(*, mul)
 binary_op(-, sub)
 binary_op(/, div)
 
-jscall(::typeof(add), x, y) = jscall(:(flux.add), x, y)
-jscall(::typeof(sub), x, y) = jscall(:(flux.sub), x, y)
-jscall(::typeof(mul), x, y) = jscall(:(flux.mul), x, y)
-jscall(::typeof(div), x, y) = jscall(:(flux.div), x, y)
+jscall(::typeof(add), x, y) = jscall(:(+), x, y)
+jscall(::typeof(sub), x, y) = jscall(:(-), x, y)
+jscall(::typeof(mul), x, y) = jscall(:(*), x, y)
+jscall(::typeof(div), x, y) = jscall(:(/), x, y)
 
 @primitive Trace function (BN::BatchNorm)(x)
   μ, σ, γ, β, λ = BN.μ, BN.σ, BN.γ, BN.β, BN.λ

--- a/src/lib.jl
+++ b/src/lib.jl
@@ -1,40 +1,40 @@
-using NNlib: cdims, padtuple, pdims
+using NNlib: cdims, padtuple, pdims, conv
 
-struct Shape{T,N}
-  dims::NTuple{N,Int}
-end
+# struct Shape{T,N}
+#   dims::NTuple{N,Int}
+# end
+#
+# VecShape{T} = Shape{T,1}
+# MatShape{T} = Shape{T,2}
+#
+# Shape{T}(dims::Vararg{Integer,N}) where {T,N} = Shape{T,N}(dims)
+# Shape{T}(dims::NTuple{N,Integer}) where {T,N} = Shape{T,N}(dims)
+#
+# Base.size(s::Shape) = s.dims
+# Base.size(s::Shape, n) = s.dims[n]
+# Base.ndims(s::Shape{T,N}) where {T,N} = N
+# Base.length(s::Shape) = prod(s.dims)
+# Base.eltype(s::Shape{T}) where T = T
+#
+# Base.sizeof(s::Shape{T}) where T = sizeof(T)*prod(size(s))
+# NNlib.padtuple(x::FluxJS.Shape, p) = padtuple(size(x), p)
 
-VecShape{T} = Shape{T,1}
-MatShape{T} = Shape{T,2}
-
-Shape{T}(dims::Vararg{Integer,N}) where {T,N} = Shape{T,N}(dims)
-Shape{T}(dims::NTuple{N,Integer}) where {T,N} = Shape{T,N}(dims)
-
-Base.size(s::Shape) = s.dims
-Base.size(s::Shape, n) = s.dims[n]
-Base.ndims(s::Shape{T,N}) where {T,N} = N
-Base.length(s::Shape) = prod(s.dims)
-Base.eltype(s::Shape{T}) where T = T
-
-Base.sizeof(s::Shape{T}) where T = sizeof(T)*prod(size(s))
-NNlib.padtuple(x::FluxJS.Shape, p) = padtuple(size(x), p)
-
-function Base.show(io::IO, s::Shape{T}) where T
-  print(io, "Shape{$T}(")
-  join(io, s.dims, ", ")
-  print(io, ")")
-end
+# function Base.show(io::IO, s::Shape{T}) where T
+#   print(io, "Shape{$T}(")
+#   join(io, s.dims, ", ")
+#   print(io, ")")
+# end
 
 # Library of mathematical functions we consider primitive.
 # TODO: store Julia functions and types, to avoid deeplearn.js-specific functions
 
 # matmul
 
-shape(::typeof(*), A::MatShape{T}, B::VecShape{T}) where T =
-  Shape{T}(size(A,1))
+# shape(::typeof(*), A::MatShape{T}, B::VecShape{T}) where T =
+  # Shape{T}(size(A,1))
 
-shape(::typeof(*), A::MatShape{T}, B::MatShape{T}) where T =
-  Shape{T}(size(A,1),size(B,2))
+# shape(::typeof(*), A::MatShape{T}, B::MatShape{T}) where T =
+  # Shape{T}(size(A,1),size(B,2))
 
 matVecMul(args...) = *(args...)
 
@@ -69,45 +69,46 @@ jscall(::typeof(concat1D), a, b) = jscall(:(math.concat1D), a, b)
 
 jscall(::typeof(softmax), x) = jscall(:(math.softmax), x)
 
-shape(::typeof(softmax), x) = shape(x)
+# shape(::typeof(softmax), x) = shape(x)
 
 # conv2d
 
 @primitive Trace function (c::Conv)(x)
+  out = conv(val(x), c.weight, stride = c.stride, pad = c.pad)
   pad = 0
   !all(x-> x == c.pad[1], c.pad)?
     throw(error("Assymetric padding is unsupported by deeplearn-js")):
     pad = c.pad[1]
-
-  conv = StagedArray(conv2d, x, c.weight, padtuple(x,c.stride), pad)
-
+  y = StagedArray(conv2d, x, c.weight, padtuple(x,c.stride), pad, v=out)
   σ, b = c.σ, reshape(c.bias, map(_->1, c.stride)..., :, 1)
-  overdub(Trace(), (x, σ, b) -> (σ).(x .+ b), conv, σ, b)
+  overdub(Trace(), (x, σ, b) -> (σ).(x .+ b), y, σ, b)
 end
 
 jscall(::typeof(conv2d), x...) = jscall(:(tf.conv2d), x...)
 
-shape(::typeof(conv2d), x::Shape{T}, weight, stride, pad) where T =
-  Shape{T}(cdims(size(x), size(weight), padtuple(x, pad), stride))
+# shape(::typeof(conv2d), x::Shape{T}, weight, stride, pad) where T =
+#   Shape{T}(cdims(size(x), size(weight), padtuple(x, pad), stride))
 
 # maxpool
 
 @primitive Trace function maxpool(x::AbstractArray, k; pad = map(_->0,k), stride = k)
+  out = maxpool(val(x), k, pad=pad, stride=stride)
+
   !all(x-> x == pad[1], pad)?
     throw(error("Assymetric padding is unsupported by deeplearn-js")):
     pad = pad[1]
 
-  StagedArray(maxpool, x, k, pad, stride)
+  StagedArray(maxpool, x, k, pad, stride, v=out)
 end
 
 jscall(::typeof(maxpool), x, k, pad, stride) = jscall(:(math.maxPool), x, k, stride, pad)
 
-shape(::typeof(maxpool), x::Shape{T}, k, pad, stride) where T = Shape{T}(pdims(size(x), k, padtuple(x, pad), stride))
+# shape(::typeof(maxpool), x::Shape{T}, k, pad, stride) where T = Shape{T}(pdims(size(x), k, padtuple(x, pad), stride))
 
 # broadcasted ops
 
-shape(::typeof(broadcast), f, xs...) =
-  Shape{eltype(xs[1])}(Base.Broadcast.broadcast_shape(size.(xs)...)...)
+# shape(::typeof(broadcast), f, xs...) =
+#   Shape{eltype(xs[1])}(Base.Broadcast.broadcast_shape(size.(xs)...)...)
 
 bcastable(+, *, tanh, relu, σ)
 
@@ -116,11 +117,35 @@ jscall(::typeof(broadcast), ::typeof(σ), x) = jscall(:(math.sigmoid), x)
 jscall(::typeof(broadcast), ::typeof(tanh), x) = jscall(:(math.tanh), x)
 jscall(::typeof(broadcast), ::typeof(relu), x) = jscall(:(math.relu), x)
 
-shape(::typeof(reshape), x::Shape{T}, i...) where T =
-  Shape{T}(Base._reshape_uncolon(x, i))
+# shape(::typeof(reshape), x::Shape{T}, i...) where T =
+#   Shape{T}(Base._reshape_uncolon(x, i))
+#
+# shape(x) = x
+# shape(x::Shape) = x
+# shape(x::Tuple) = shape.(x)
+# shape(x::AbstractArray) = Shape{eltype(x)}(size(x)...)
+# shape(x::TrackedArray) = shape(x.data)
 
-shape(x) = x
-shape(x::Shape) = x
-shape(x::Tuple) = shape.(x)
-shape(x::AbstractArray) = Shape{eltype(x)}(size(x)...)
-shape(x::TrackedArray) = shape(x.data)
+# reshape
+
+@primitive Trace function Base.reshape(parent::AbstractArray, dims...)
+  dims = any(x -> val(x) isa Colon, dims) ?
+  map((x, y) -> val(x) isa Colon? y : x
+    , dims, Base._reshape_uncolon(val(parent), val.(dims))) : dims
+  StagedArray(reshape, parent, dims...)
+end
+
+@primitive t::Trace function Base.reshape(parent, dims::Tuple{Vararg{Union{Int,Colon}}})
+  dims = Base._reshape_uncolon(val(parent), val.(dims))
+  overdub(t, (x...)-> reshape(x...), parent, dims...)
+end
+
+jscall(::typeof(reshape), p, dims...) =
+  jscall(:(math.reshape), p, jscall(:(Array().constructor), dims...))
+
+# size
+@primitive Trace Base.size(x...) =
+  StagedArray(size, x...)
+
+jscall(::typeof(size), x) = jscall(:(flux.getprop), x, "shape")
+jscall(s::typeof(size), x, i) = jscall(:(flux.getprop), jscall(s, x), i)

--- a/src/lib.jl
+++ b/src/lib.jl
@@ -162,10 +162,18 @@ jscall(::typeof(view), x, start, length) =
 
 @primitive Trace start(x::StagedArray) = StagedArray(start, x)
 
-@primitive Trace function Base.getindex(t::StagedArray, i::Union{Int,StagedArray{Int}})
-  index =  primitive(Trace(), (-), i, 1)
-  StagedArray(getindex, t, index, v = val(t)[val(i)])
+@primitive Trace Base.getindex(t::StagedArray, i::Int) = 
+  StagedArray(getindex, t, i - 1, v = val(t)[i])
+
+@primitive Trace function Base.getindex(t, i::StagedArray{Int})
+  index = overdub(Trace(), x -> x - 1, i)
+  StagedArray(getindex, t, i, v = val(t)[val(i)])
 end
+
+@primitive Trace function tuple(args...)
+  any(x -> x isa StagedArray, args) ? StagedArray(tuple, args...) : trace(tuple, args...)
+end
+
 
 # @primitive Trace function Base.getindex(t::StagedArray, i...)
 #   _begin = []
@@ -226,5 +234,5 @@ binary_op(*, mul)
 binary_op(-, sub)
 
 jscall(::typeof(add), x, y) = jscall(:(flux.add), x, y)
-# jscall(::typeof(-), x::Union{StagedArray{Int},Int}, y::Union{StagedArray{Int},Int}) = jscall(:(flux.sub), x, y)
+jscall(::typeof(sub), x, y) = jscall(:(flux.sub), x, y)
 jscall(::typeof(mul), x, y) = jscall(:(flux.mul), x, y)

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -16,16 +16,16 @@ end
 Base.size(x::StagedArray) = size(x.val)
 
 Base.show(io::IO, ::MIME"text/plain", s::StagedArray) =
-  print(io, "StagedArray{$(eltype(s))}($(size(s.val)), $(s.graph))")
+  print(io, "StagedArray{$(eltype(s)),$(ndims(s))}($(s.val), $(s.graph))")
 
 Base.show(io::IO, s::StagedArray) =
-  print(io, "StagedArray{$(eltype(s))}($(size(s.val)))")
+  print(io, "StagedArray{$(eltype(s)),$(ndims(s))}")
 
 val(x) = x
-val(x::StagedArray) = x.val
+val(x::StagedArray) = val(x.val)
 val(x::Tuple) = val.(x)
 
-dims(x) = size(x)
+dims(x) = ndims(x)
 dims(x::Tuple) = length(x)
 dims(x::StagedArray) = dims(val(x))
 
@@ -36,11 +36,11 @@ graph(x) = DataFlow.constant(x)
 vcall(args...) = DataFlow.vertex(DataFlow.Call(), graph.(args)...)
 
 StagedArray(f, args...; v=val(f(val.(args)...))) =
-  StagedArray{eltype(v),dims(v)}(vcall(f, args...),v)
-
+  StagedArray{typeof(v),dims(v)}(vcall(f, args...),v)
 
 stage(x::AbstractArray{T,N}, v) where {T,N} = StagedArray{T,N}(v, val(x))
-stage(x::Real, v) = StagedArray{typeof(x),0}(v, val(x))
+stage(x::Tuple, v) = StagedArray{Tuple{eltype(x)},dims(x)}(v, val(x))
+stage(x::Real, v) = StagedArray{typeof(x),dims(x)}(v, val(x))
 stage(x, v) = error("Unsupported type $(typeof(x))")
 
 trace(f, args...; meta = Trace()) = overdub(meta, f, args...)

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -36,7 +36,6 @@ graph(x) = DataFlow.constant(x)
 vcall(args...) = DataFlow.vertex(DataFlow.Call(), graph.(args)...)
 
 function StagedArray(f, args...; v=val(f(val.(args)...)))
-  @show f, args
   StagedArray{typeof(v),dims(v)}(vcall(f, args...),v)
 end
 
@@ -80,8 +79,11 @@ end
 
 control(a::IVertex, b::IVertex = DataFlow.inputnode()) = vcall(control, a, b)
 
+data(x) = Flux.data(x)
+data(x::Tuple) = data.(x)
+
 @primitive ctx::Trace function (f::Flux.Recur)(args...)
-  push!(ctx.states, f.init)
+  push!(ctx.states, data(f.init))
   i = length(ctx.states)-1
   states = control(DataFlow.constant(:states))
   state = stage(f.init, vcall(getindex, states, i))

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -36,7 +36,7 @@ graph(x) = DataFlow.constant(x)
 vcall(args...) = DataFlow.vertex(DataFlow.Call(), graph.(args)...)
 
 function StagedArray(f, args...; v=val(f(val.(args)...)))
-  @show f, args, v
+  @show f, args
   StagedArray{typeof(v),dims(v)}(vcall(f, args...),v)
 end
 
@@ -92,7 +92,6 @@ control(a::IVertex, b::IVertex = DataFlow.inputnode()) = vcall(control, a, b)
                              vertex(DataFlow.Do(),
                                     vcall(setindex!, states, unwrap(h), i),
                                     graph(y))))
-  @show λ
   wrap(y, vcall(λ, args...))
 end
 

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -35,9 +35,8 @@ graph(x::StagedArray) = x.graph
 graph(x) = DataFlow.constant(x)
 vcall(args...) = DataFlow.vertex(DataFlow.Call(), graph.(args)...)
 
-function StagedArray(f, args...; v=val(f(val.(args)...)))
+StagedArray(f, args...; v=val(f(val.(args)...))) =
   StagedArray{typeof(v),dims(v)}(vcall(f, args...),v)
-end
 
 stage(x::AbstractArray{T,N}, v) where {T,N} = StagedArray{T,N}(v, val(x))
 stage(x::Tuple, v) = StagedArray{Tuple{eltype(x)},dims(x)}(v, val(x))

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -79,11 +79,12 @@ end
 
 control(a::IVertex, b::IVertex = DataFlow.inputnode()) = vcall(control, a, b)
 
-data(x) = Flux.data(x)
-data(x::Tuple) = data.(x)
+tensor(x::TrackedArray) = StagedArray(tensor, Flux.data(x), reverse(size(x)),v=Flux.data(x))
+tensor(x::Tuple) = tensor.(x)
+jscall(::typeof(tensor), x...) = jscall(:(math.tensor), x...)
 
 @primitive ctx::Trace function (f::Flux.Recur)(args...)
-  push!(ctx.states, data(f.init))
+  push!(ctx.states, tensor(f.init))
   i = length(ctx.states)-1
   states = control(DataFlow.constant(:states))
   state = stage(f.init, vcall(getindex, states, i))

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -13,7 +13,7 @@ struct StagedArray{T,N} <: AbstractArray{T,N}
   val
 end
 
-Base.size(x::StagedArray) = size(x.val)
+Base.size(x::StagedArray) = size(val(x))
 
 Base.show(io::IO, ::MIME"text/plain", s::StagedArray) =
   print(io, "StagedArray{$(eltype(s)),$(ndims(s))}($(s.val), $(s.graph))")


### PR DESCRIPTION
StagedArray uses `val` field instead of `dims`. 