### PR TITLE
Update vcat primitive

### DIFF
--- a/src/lib.jl
+++ b/src/lib.jl
@@ -27,14 +27,16 @@ jscall(::typeof(+), a, b) = jscall(:(math.add), b, a)
 # cat
 
 concat1D(a, b) = vcat(a, b)
+concat(a, b) = vcat(a, b)
 
 @primitive Trace vcat(a::AbstractVector, b::AbstractVector) =
   StagedArray(concat1D, a, b)
 
 @primitive Trace vcat(a::AbstractMatrix, b::AbstractMatrix) =
-  error("concat2D not implemented")
+  StagedArray(concat, a, b)
 
-jscall(::typeof(concat1D), a, b) = jscall(:(math.concat1D), a, b)
+jscall(::typeof(concat1D), a, b) = jscall(:(math.concat1d), a, b)
+jscall(::typeof(concat), a, b) = jscall(:(math.concat), jscall(tuple, a, b), -1)
 
 # softmax
 

--- a/src/lib.jl
+++ b/src/lib.jl
@@ -35,7 +35,7 @@ concat(a, b) = vcat(a, b)
 @primitive Trace vcat(a::AbstractMatrix, b::AbstractMatrix) =
   StagedArray(concat, a, b)
 
-jscall(::typeof(concat1D), a, b) = jscall(:(math.concat1d), a, b)
+jscall(::typeof(concat1D), a, b) = jscall(:(math.concat1d), jscall(tuple,a, b))
 jscall(::typeof(concat), a, b) = jscall(:(math.concat), jscall(tuple, a, b), -1)
 
 # softmax

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,14 @@ end
     testjs(w, m, x)
 end
 
+@testset "vcat" begin
+    m = (x) -> vcat(x, ones(2))
+    testjs(w, m, x)
+
+    m = (x) -> vcat(x, ones(2, 2))
+    testjs(w, m, rand(3, 2))
+end
+
 @testset "softmax" begin
     m = x -> softmax(x)
     testjs(w, m, x)


### PR DESCRIPTION
tf-js currently supports concat operation for tensors of ranks higher than 1 as well.